### PR TITLE
WP-70 Add transformation & color to table block

### DIFF
--- a/src/blocks/table-cell/index.tsx
+++ b/src/blocks/table-cell/index.tsx
@@ -25,7 +25,7 @@ import edit from './edit';
 export const name: string = 'travelopia/table-cell';
 
 export const settings: BlockConfiguration = {
-	apiVersion: 2,
+	apiVersion: 3,
 	icon,
 	title: __( 'Cell', 'tp' ),
 	description: __( 'Individual cell of the table.', 'tp' ),

--- a/src/blocks/table-column/index.tsx
+++ b/src/blocks/table-column/index.tsx
@@ -21,7 +21,7 @@ import edit from './edit';
 export const name: string = 'travelopia/table-column';
 
 export const settings: BlockConfiguration = {
-	apiVersion: 2,
+	apiVersion: 3,
 	icon,
 	title: __( 'Column', 'tp' ),
 	description: __( 'Individual column of the table.', 'tp' ),

--- a/src/blocks/table-row/index.tsx
+++ b/src/blocks/table-row/index.tsx
@@ -21,7 +21,7 @@ import edit from './edit';
 export const name: string = 'travelopia/table-row';
 
 export const settings: BlockConfiguration = {
-	apiVersion: 2,
+	apiVersion: 3,
 	icon,
 	title: __( 'Row', 'tp' ),
 	description: __( 'Individual row of the table.', 'tp' ),

--- a/src/blocks/table/index.tsx
+++ b/src/blocks/table/index.tsx
@@ -26,7 +26,7 @@ import './editor.scss';
 export const name: string = 'travelopia/table';
 
 export const settings: BlockConfiguration = {
-	apiVersion: 2,
+	apiVersion: 3,
 	icon,
 	title: __( 'Table', 'tp' ),
 	description: __( 'Create structured content in rows and columns to display information.', 'tp' ),


### PR DESCRIPTION
## Description
This PR adds transformation and color features to the table block

- [x] Ability to select text and background colors on a row
- [x] Ability to select text and background colors on a column
- [x] Ability to transform a cell into a Paragraph, Image, Heading, List

### Screenshots

Setting color on row -
<img width="1268" alt="image" src="https://github.com/Travelopia/wordpress-blocks/assets/60139930/2b8130b7-3b3d-49d8-924f-8b005b58209b">

Transform table-cell to any other block -
<img width="502" alt="image" src="https://github.com/Travelopia/wordpress-blocks/assets/60139930/705300e6-ade3-4783-b827-94593c498f20">

Setting color on column -
<img width="857" alt="image" src="https://github.com/Travelopia/wordpress-blocks/assets/60139930/f9565746-b8b3-4a7a-ab1b-97f170b9f27b">

Frontend -
<img width="486" alt="image" src="https://github.com/Travelopia/wordpress-blocks/assets/60139930/dbe86aa4-cc17-436e-bb17-6fba6b6a1306">
