### PR TITLE
WP-70 fix broken block editor styling

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -13,13 +13,17 @@ namespace Travelopia\Blocks;
  * @return void
  */
 function bootstrap(): void {
-	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_block_editor_assets' );
+	add_action( 'enqueue_block_assets', __NAMESPACE__ . '\\enqueue_block_editor_assets' );
 }
 
 /**
  * Enqueue Editor Assets.
  */
 function enqueue_block_editor_assets(): void {
+	if ( ! is_admin() ) {
+		return;
+	}
+
 	// Get block asset details.
 	$block_assets = [];
 	$asset_file   = __DIR__ . '/../dist/blocks.asset.php';


### PR DESCRIPTION
## Description
With the update of `apiVersion` to 3 in the block settings, the block editor assets are no longer applied. In latest version, the post editor is rendered in an iFrame. Though the editor.css will be enqueued but won't be applied on the block present inside the iframe. 
WordPress has suggested to use this approach to enqueue the editor assets - https://developer.wordpress.org/block-editor/how-to-guides/enqueueing-assets-in-the-editor/#editor-content-scripts-and-styles

Refer to this on why editor is being rendered in iframe - https://make.wordpress.org/core/2021/06/29/blocks-in-an-iframed-template-editor/

### Screenshots

Before - 
<img width="708" alt="image" src="https://github.com/Travelopia/wordpress-blocks/assets/60139930/54e1c816-a1a7-4417-a899-0e6fe2420aa1">

After - 
<img width="1085" alt="image" src="https://github.com/Travelopia/wordpress-blocks/assets/60139930/3690688d-04ad-47ac-b857-27187bc62960">


