### PR TITLE
WP-70 Fix Unequal length row/column merge and conflict with thead/tfoot

### DIFF
--- a/src/blocks/table-column/toolbar.tsx
+++ b/src/blocks/table-column/toolbar.tsx
@@ -571,8 +571,6 @@ export default function Toolbar( {
 		// Get colspans.
 		const mergeIntoAttributes = getBlockAttributes( toColumn.clientId );
 		const mergeFromAttributes = getBlockAttributes( fromColumn.clientId );
-		const mergeIntoColspan: number = parseInt( mergeIntoAttributes?.colSpan ?? 1 );
-		const mergeFromColspan: number = parseInt( mergeFromAttributes?.colSpan ?? 1 );
 
 		// Get rowspans.
 		const mergeIntoRowspan: number = parseInt( mergeIntoAttributes?.rowSpan ?? 1 );
@@ -582,6 +580,9 @@ export default function Toolbar( {
 		if ( mergeIntoRowspan !== mergeFromRowspan ) {
 			return;
 		}
+
+		const mergeIntoColspan: number = parseInt( mergeIntoAttributes?.colSpan ?? 1 );
+		const mergeFromColspan: number = parseInt( mergeFromAttributes?.colSpan ?? 1 );
 
 		// Update colspan.
 		updateBlockAttributes( toColumn.clientId, { colSpan: mergeIntoColspan + mergeFromColspan } );
@@ -607,8 +608,6 @@ export default function Toolbar( {
 		// Get rowspans.
 		const mergeIntoAttributes = getBlockAttributes( toColumn.clientId );
 		const mergeFromAttributes = getBlockAttributes( fromColumn.clientId );
-		const mergeIntoRowspan: number = parseInt( mergeIntoAttributes?.rowSpan ?? 1 );
-		const mergeFromRowspan: number = parseInt( mergeFromAttributes?.rowSpan ?? 1 );
 
 		// Get colspans.
 		const mergeIntoColspan: number = parseInt( mergeIntoAttributes?.colSpan ?? 1 );
@@ -618,6 +617,9 @@ export default function Toolbar( {
 		if ( mergeIntoColspan !== mergeFromColspan ) {
 			return;
 		}
+
+		const mergeIntoRowspan: number = parseInt( mergeIntoAttributes?.rowSpan ?? 1 );
+		const mergeFromRowspan: number = parseInt( mergeFromAttributes?.rowSpan ?? 1 );
 
 		// Update rowspan.
 		updateBlockAttributes( toColumn.clientId, { rowSpan: mergeIntoRowspan + mergeFromRowspan } );


### PR DESCRIPTION
## Description
This PR fixes these - 
1. Before merging, there is a check added to validate that the columns/rows to be merged are of equal length.
2. The tbody's first row merging is being conflicted with the thead elements.