### PR TITLE
WP-70 Ability to align content inside column block

### DIFF
--- a/src/blocks/table-column/index.tsx
+++ b/src/blocks/table-column/index.tsx
@@ -16,11 +16,6 @@ import {
 import edit from './edit';
 
 /**
- * Styles
- */
-import './editor.scss';
-
-/**
  * Block data.
  */
 export const name: string = 'travelopia/table-column';
@@ -61,7 +56,7 @@ export const settings: BlockConfiguration = {
 			text: true,
 			background: true,
 		},
-		align: true,
+		align: [ 'left', 'center', 'right' ],
 	},
 	edit,
 	save() {


### PR DESCRIPTION
## Description
This PR adds ability to align the content inside the column block. It can be aligned left, center, right. If none selected, no styling is applied.

<img width="572" alt="image" src="https://github.com/Travelopia/wordpress-blocks/assets/60139930/e0fc303d-27b9-4e28-a2da-7b5e26410ae6">

<img width="499" alt="image" src="https://github.com/Travelopia/wordpress-blocks/assets/60139930/b736b48b-2d3c-4a8c-936f-88e5566f2315">

<img width="457" alt="image" src="https://github.com/Travelopia/wordpress-blocks/assets/60139930/a9558cac-f3cb-4e35-931c-c69787f332af">

Note: I'm using `flex` properties to align the content as column can have any other type of block apart from containing text. Also, this property is not provided on the cell block because if an image is used, one can't align it since cell won't be there.